### PR TITLE
Update Player Collision + Players no longer collide with each other

### DIFF
--- a/.addon
+++ b/.addon
@@ -32,6 +32,55 @@
     "PerMapRanking": true,
     "GameNetworkType": "Multiplayer",
     "MaxPlayers": 16,
-    "GameCategory": "Parkour"
+    "GameCategory": "Parkour",
+    "Collision": {
+      "Defaults": {
+        "solid": "Collide",
+        "trigger": "Trigger",
+        "ladder": "Ignore",
+        "water": "Trigger",
+        "player": "Unset"
+      },
+      "Pairs": [
+        {
+          "a": "solid",
+          "b": "solid",
+          "r": "Collide"
+        },
+        {
+          "a": "trigger",
+          "b": "playerclip",
+          "r": "Ignore"
+        },
+        {
+          "a": "trigger",
+          "b": "solid",
+          "r": "Trigger"
+        },
+        {
+          "a": "solid",
+          "b": "trigger",
+          "r": "Collide"
+        },
+        {
+          "a": "playerclip",
+          "b": "solid",
+          "r": "Collide"
+        },
+        {
+          "a": "player",
+          "b": "player",
+          "r": "Ignore"
+        },
+        {
+          "a": "solid",
+          "b": "player"
+        },
+        {
+          "a": "trigger",
+          "b": "player"
+        }
+      ]
+    }
   }
 }

--- a/code/Players/StrafePlayer.cs
+++ b/code/Players/StrafePlayer.cs
@@ -24,9 +24,8 @@ internal partial class StrafePlayer : Sandbox.Player
 		base.Respawn();
 
 		SetModel( "models/citizen/citizen.vmdl" );
-		SetInteractsAs( CollisionLayer.Player );
-		SetInteractsExclude( CollisionLayer.Player );
-		SetInteractsWith( CollisionLayer.Trigger | CollisionLayer.Water | CollisionLayer.Solid );
+		Tags.Add("player");
+		EnableAllCollisions = false;
 
 		Controller = new StrafeController()
 		{


### PR DESCRIPTION
Code was leftover from the now obsolete collision system so I added a "player" tag and made it so players no longer collide with each other.

This means players no longer get stuck inside each other when they respawn and momentum no longer gets killed by hopping into each other.